### PR TITLE
Prevent crash caused by kicking players while iterating player list

### DIFF
--- a/common/src/main/java/io/github/gaming32/bingo/Bingo.java
+++ b/common/src/main/java/io/github/gaming32/bingo/Bingo.java
@@ -96,11 +96,9 @@ public class Bingo {
 
         Event.SERVER_TICK_END.register(instance -> {
             if (activeGame != null && activeGame.isRequireClient()) {
-                for (final ServerPlayer player : instance.getPlayerList().getPlayers()) {
-                    if (player.tickCount == 60 && !Bingo.isInstalledOnClient(player)) {
-                        player.connection.disconnect(BingoGame.REQUIRED_CLIENT_KICK);
-                    }
-                }
+                instance.getPlayerList().getPlayers().stream().filter(
+                        player -> player.tickCount == 60 && !Bingo.isInstalledOnClient(player)
+                ).toList().forEach(player -> player.connection.disconnect(BingoGame.REQUIRED_CLIENT_KICK));
             }
         });
 


### PR DESCRIPTION
I think #16 is caused by players being kicked while iterating the player list, so a possible fix is to collect the list of players that need to be kicked first.

This makes me wonder what would happen if a player happens to leave at a bad moment, but at least this change effectively solves #16 for me.