### PR TITLE
add optional time limit

### DIFF
--- a/src/main/java/io/github/gaming32/bingo/Bingo.java
+++ b/src/main/java/io/github/gaming32/bingo/Bingo.java
@@ -22,6 +22,7 @@ import io.github.gaming32.bingo.network.messages.s2c.InitBoardPayload;
 import io.github.gaming32.bingo.network.messages.s2c.RemoveBoardPayload;
 import io.github.gaming32.bingo.network.messages.s2c.ResyncStatesPayload;
 import io.github.gaming32.bingo.network.messages.s2c.SyncTeamPayload;
+import io.github.gaming32.bingo.network.messages.s2c.UpdateEndTimePayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateProgressPayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateStatePayload;
 import io.github.gaming32.bingo.platform.BingoNetworking;
@@ -192,6 +193,7 @@ public class Bingo {
             registrar.register(PacketFlow.CLIENTBOUND, SyncTeamPayload.TYPE, SyncTeamPayload.CODEC);
             registrar.register(PacketFlow.CLIENTBOUND, UpdateProgressPayload.TYPE, UpdateProgressPayload.CODEC);
             registrar.register(PacketFlow.CLIENTBOUND, UpdateStatePayload.TYPE, UpdateStatePayload.CODEC);
+            registrar.register(PacketFlow.CLIENTBOUND, UpdateEndTimePayload.TYPE, UpdateEndTimePayload.CODEC);
             registrar.register(null, ManualHighlightPayload.TYPE, ManualHighlightPayload.CODEC);
         });
     }

--- a/src/main/java/io/github/gaming32/bingo/BingoCommand.java
+++ b/src/main/java/io/github/gaming32/bingo/BingoCommand.java
@@ -147,6 +147,10 @@ public class BingoCommand {
     private static final CommandSwitch<Long> SEED = CommandSwitch
         .argument("--seed", LongArgumentType.longArg())
         .build(RandomSupport::generateUniqueSeed);
+    private static final CommandSwitch<Integer> TIME_LIMIT = CommandSwitch
+        .argument("--time-limit", TimeArgument.time(-1))
+        .getter(IntegerArgumentType::getInteger)
+        .build(-1);
     private static final CommandSwitch<Integer> AUTO_FORFEIT_TIME = CommandSwitch
         .argument("--auto-forfeit-time", TimeArgument.time(0))
         .getter(IntegerArgumentType::getInteger)
@@ -382,6 +386,23 @@ public class BingoCommand {
                     )
                 )
             )
+            .then(literal("time-limit")
+                .requires(source -> source.permissions().hasPermission(Permissions.COMMANDS_GAMEMASTER))
+                .then(literal("set")
+                    .then(argument("time-limit", TimeArgument.time(-1))
+                        .executes(ctx -> {
+                            final var game = ((MinecraftServerExt) ctx.getSource().getServer()).bingo$getGame();
+                            if (game == null) {
+                                throw NO_GAME_RUNNING.create();
+                            }
+                            int timeLimit = IntegerArgumentType.getInteger(ctx, "time-limit");
+                            final long scheduledEndTime = timeLimit > 0 ? ctx.getSource().getServer().overworld().getGameTime() + timeLimit : 0;
+                            game.setScheduledEndTime(ctx.getSource().getServer(), scheduledEndTime);
+                            return 1;
+                        })
+                    )
+                )
+            )
             .then(literal("nerf")
                 .then(literal("add")
                     .then(argument("player", EntityArgument.player())
@@ -422,6 +443,7 @@ public class BingoCommand {
             SHAPE.addTo(startCommand);
             SIZE.addTo(startCommand);
             SEED.addTo(startCommand);
+            TIME_LIMIT.addTo(startCommand);
             AUTO_FORFEIT_TIME.addTo(startCommand);
             DIFFICULTY.addTo(startCommand);
             GAMEMODE.addTo(startCommand);
@@ -465,6 +487,7 @@ public class BingoCommand {
         final boolean requireClient = REQUIRE_CLIENT.get(context);
         final boolean continueAfterWin = CONTINUE_AFTER_WIN.get(context);
         final boolean includeInactiveTeams = INCLUDE_INACTIVE_TEAMS.get(context);
+        final int timeLimit  = TIME_LIMIT.get(context);
         final int autoForfeitTicks = AUTO_FORFEIT_TIME.get(context);
 
         final Set<PlayerTeam> teams = LinkedHashSet.newLinkedHashSet(teamCount);
@@ -515,7 +538,8 @@ public class BingoCommand {
         }
         Bingo.LOGGER.info("Generated board (seed {}):\n{}", seed, board);
 
-        final var game = new BingoGame(board, gamemode, requireClient, continueAfterWin, autoForfeitTicks, teams.toArray(PlayerTeam[]::new));
+        final long scheduledEndTime = timeLimit > 0 ? context.getSource().getServer().overworld().getGameTime() + timeLimit : 0;
+        final var game = new BingoGame(board, gamemode, requireClient, continueAfterWin, scheduledEndTime, autoForfeitTicks, teams.toArray(PlayerTeam[]::new));
 
         for (ServerPlayer player : context.getSource().getServer().getPlayerList().getPlayers()) {
             if (Bingo.CONFIG.getNerfedPlayers().contains(player.getUUID())) {

--- a/src/main/java/io/github/gaming32/bingo/client/BingoClient.java
+++ b/src/main/java/io/github/gaming32/bingo/client/BingoClient.java
@@ -20,9 +20,11 @@ import io.github.gaming32.bingo.platform.BingoClientPlatform;
 import io.github.gaming32.bingo.platform.BingoPlatform;
 import io.github.gaming32.bingo.platform.event.ClientEvents;
 import io.github.gaming32.bingo.platform.registrar.KeyMappingBuilder;
+import io.github.gaming32.bingo.util.BingoUtil;
 import io.github.gaming32.bingo.util.Identifiers;
 import io.github.gaming32.bingo.util.Vec2i;
 import net.minecraft.ChatFormatting;
+import net.minecraft.SharedConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -175,6 +177,34 @@ public class BingoClient {
         final PositionAndScale pos = getBoardPosition();
         renderBingo(graphics, minecraft.screen instanceof ChatScreen, pos);
 
+        final Font font = minecraft.font;
+        final int scoreX = (int)(pos.x() * pos.scale() + getBoardWidth() * pos.scale() / 2);
+        int scoreY;
+        if (CONFIG.getBoardCorner().isOnBottom) {
+            scoreY = (int)((pos.y() - BOARD_OFFSET) * pos.scale() - font.lineHeight);
+        } else {
+            scoreY = (int)(pos.y() * pos.scale() + (getBoardHeight() + BOARD_OFFSET) * pos.scale());
+        }
+        final int shift = CONFIG.getBoardCorner().isOnBottom ? -12 : 12;
+
+        if (clientGame.scheduledEndTime() > 0) {
+            long serverTime = 0;
+            if (minecraft.level instanceof ClientLevel clientLevel) {
+                serverTime = clientLevel.getGameTime();
+            }
+            long remainingTimeTicks = clientGame.scheduledEndTime() - serverTime;
+            String formatedRemainingTime = " - " + BingoUtil.formatRemainingTime(remainingTimeTicks);
+            int color = 0xffffffff;
+            if (remainingTimeTicks < 30 * SharedConstants.TICKS_PER_MINUTE)
+                color = 0xffffaf00;
+            if (remainingTimeTicks < 5 * SharedConstants.TICKS_PER_MINUTE)
+                color = 0xffff0000;
+            final MutableComponent remainingTimeLabel = Component.translatable("bingo.remaining_time");
+            graphics.text(font, remainingTimeLabel, scoreX - font.width(remainingTimeLabel), scoreY, color);
+            graphics.text(font, Component.literal(formatedRemainingTime), scoreX, scoreY, color);
+            scoreY += shift;
+        }
+
         if (CONFIG.isShowScoreCounter() && clientGame.renderMode() == BingoGameMode.RenderMode.ALL_TEAMS) {
             class TeamValue {
                 final BingoBoard.Teams team;
@@ -200,15 +230,6 @@ public class BingoClient {
 
             Arrays.sort(teams, Comparator.comparing(v -> -v.score)); // Sort in reverse
 
-            final Font font = minecraft.font;
-            final int scoreX = (int)(pos.x() * pos.scale() + getBoardWidth() * pos.scale() / 2);
-            int scoreY;
-            if (CONFIG.getBoardCorner().isOnBottom) {
-                scoreY = (int)((pos.y() - BOARD_OFFSET) * pos.scale() - font.lineHeight);
-            } else {
-                scoreY = (int)(pos.y() * pos.scale() + (getBoardHeight() + BOARD_OFFSET) * pos.scale());
-            }
-            final int shift = CONFIG.getBoardCorner().isOnBottom ? -12 : 12;
             for (final TeamValue teamValue : teams) {
                 if (teamValue.score == 0) break;
                 final PlayerTeam team = clientGame.teams()[teamValue.team.getFirstIndex()];

--- a/src/main/java/io/github/gaming32/bingo/client/ClientGame.java
+++ b/src/main/java/io/github/gaming32/bingo/client/ClientGame.java
@@ -19,6 +19,7 @@ public record ClientGame(
     BingoGameMode.RenderMode renderMode,
     @Nullable GoalProgress[] progress,
     @Nullable Integer[] manualHighlights,
-    MutableInt manualHighlightModCount
+    MutableInt manualHighlightModCount,
+    long scheduledEndTime
 ) {
 }

--- a/src/main/java/io/github/gaming32/bingo/client/ClientPayloadHandlerImpl.java
+++ b/src/main/java/io/github/gaming32/bingo/client/ClientPayloadHandlerImpl.java
@@ -9,6 +9,7 @@ import io.github.gaming32.bingo.network.messages.both.ManualHighlightPayload;
 import io.github.gaming32.bingo.network.messages.s2c.InitBoardPayload;
 import io.github.gaming32.bingo.network.messages.s2c.ResyncStatesPayload;
 import io.github.gaming32.bingo.network.messages.s2c.SyncTeamPayload;
+import io.github.gaming32.bingo.network.messages.s2c.UpdateEndTimePayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateProgressPayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateStatePayload;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -48,7 +49,8 @@ public class ClientPayloadHandlerImpl implements ClientPayloadHandler {
             payload.renderMode(),
             new GoalProgress[goalCount],
             Arrays.stream(payload.manualHighlights()).mapToObj(i -> i == 0 ? null : i - 1).toArray(Integer[]::new),
-            new MutableInt(payload.manualHighlightModCount())
+            new MutableInt(payload.manualHighlightModCount()),
+            payload.scheduledEndTime()
         );
     }
 
@@ -87,6 +89,24 @@ public class ClientPayloadHandlerImpl implements ClientPayloadHandler {
             return;
         }
         BingoClient.clientGame.states()[index] = payload.newState();
+    }
+
+    @Override
+    public void handleUpdateEndTime(UpdateEndTimePayload payload) {
+        if (!checkGamePresent(payload)) return;
+        BingoClient.clientGame = new ClientGame(
+            BingoClient.clientGame.shape(),
+            BingoClient.clientGame.size(),
+            BingoClient.clientGame.states(),
+            BingoClient.clientGame.goals(),
+            BingoClient.clientGame.teams(),
+            BingoClient.clientGame.nerfedTeams(),
+            BingoClient.clientGame.renderMode(),
+            BingoClient.clientGame.progress(),
+            BingoClient.clientGame.manualHighlights(),
+            BingoClient.clientGame.manualHighlightModCount(),
+            payload.endTime()
+        );
     }
 
     @Override

--- a/src/main/java/io/github/gaming32/bingo/game/BingoGame.java
+++ b/src/main/java/io/github/gaming32/bingo/game/BingoGame.java
@@ -14,6 +14,7 @@ import io.github.gaming32.bingo.network.messages.s2c.InitBoardPayload;
 import io.github.gaming32.bingo.network.messages.s2c.RemoveBoardPayload;
 import io.github.gaming32.bingo.network.messages.s2c.ResyncStatesPayload;
 import io.github.gaming32.bingo.network.messages.s2c.SyncTeamPayload;
+import io.github.gaming32.bingo.network.messages.s2c.UpdateEndTimePayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateProgressPayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateStatePayload;
 import io.github.gaming32.bingo.triggers.progress.ProgressibleTrigger;
@@ -44,12 +45,16 @@ import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateAdvancementsPacket;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerBossEvent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stat;
 import net.minecraft.util.ExtraCodecs;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.BossEvent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Scoreboard;
@@ -79,23 +84,27 @@ public class BingoGame {
     private final boolean continueAfterWin;
     private final int autoForfeitTicks;
     private final PlayerTeam[] teams;
+    private long scheduledEndTime;
 
+    private final RandomSource random = RandomSource.create();
     private final Map<UUID, Map<ActiveGoal, AdvancementProgress>> advancementProgress = new HashMap<>();
     private final Map<UUID, Map<ActiveGoal, GoalProgress>> goalProgress = new HashMap<>();
     private final Map<UUID, Object2IntOpenHashMap<ActiveGoal>> goalAchievedCount = new HashMap<>();
     private final Map<UUID, List<ActiveGoal>> queuedGoals = new HashMap<>();
     private final Map<UUID, Object2IntMap<Stat<?>>> baseStats = new HashMap<>();
+    private final ServerBossEvent vanillaRemainingTime = new ServerBossEvent(Mth.createInsecureUUID(this.random), Bingo.translatable("bingo.remaining_time"), BossEvent.BossBarColor.WHITE, BossEvent.BossBarOverlay.PROGRESS);
     private final OptionalLong[] lastActiveTimes;
     private BingoBoard.Teams remainingTeams;
     private BingoBoard.Teams winningTeams = BingoBoard.Teams.NONE;
     private BingoBoard.Teams finishedTeams = BingoBoard.Teams.NONE;
     private BingoBoard.Teams nerfedTeams = BingoBoard.Teams.NONE;
 
-    public BingoGame(BingoBoard board, BingoGameMode gameMode, boolean requireClient, boolean continueAfterWin, int autoForfeitTicks, PlayerTeam... teams) {
+    public BingoGame(BingoBoard board, BingoGameMode gameMode, boolean requireClient, boolean continueAfterWin, long scheduledEndTime, int autoForfeitTicks, PlayerTeam... teams) {
         this.board = board;
         this.gameMode = gameMode;
         this.requireClient = requireClient;
         this.continueAfterWin = continueAfterWin;
+        this.scheduledEndTime = scheduledEndTime;
         this.autoForfeitTicks = autoForfeitTicks;
         this.teams = teams;
         this.lastActiveTimes = new OptionalLong[teams.length];
@@ -140,7 +149,7 @@ public class BingoGame {
         final BingoBoard.Teams team = getTeam(player);
         new SyncTeamPayload(team).sendTo(player);
 
-        InitBoardPayload.create(this, team, obfuscateTeam(team, player)).sendTo(player);
+        InitBoardPayload.create(this, team, obfuscateTeam(team, player), this.scheduledEndTime).sendTo(player);
         if (!((PlayerAdvancementsAccessor)player.getAdvancements()).getIsFirstPacket()) {
             syncAdvancementsTo(player);
         }
@@ -153,6 +162,10 @@ public class BingoGame {
                     new UpdateProgressPayload(goalIndex, progress.progress(), progress.maxProgress()).sendTo(player);
                 }
             });
+        }
+
+        if (scheduledEndTime > 0 && !Bingo.isInstalledOnClient(player)) {
+            vanillaRemainingTime.addPlayer(player);
         }
     }
 
@@ -169,6 +182,39 @@ public class BingoGame {
 
     public void removePlayer(ServerPlayer player) {
         unregisterListeners(player, true);
+        vanillaRemainingTime.removePlayer(player);
+    }
+
+    public void setScheduledEndTime(MinecraftServer server, long scheduledEndTime) {
+        this.scheduledEndTime = scheduledEndTime;
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            if (Bingo.isInstalledOnClient(player)) {
+                new UpdateEndTimePayload(scheduledEndTime).sendTo(player);
+            } else {
+                vanillaRemainingTime.addPlayer(player);
+            }
+        }
+        updateVanillaRemainingTime(server);
+    }
+
+    public void updateVanillaRemainingTime(MinecraftServer server) {
+        if (vanillaRemainingTime.getPlayers().isEmpty()) {
+            return;
+        }
+        long remainingTimeTicks = scheduledEndTime - server.overworld().getGameTime();
+        String formatedRemainingTime = BingoUtil.formatRemainingTime(remainingTimeTicks);
+        if (remainingTimeTicks <= 0) {
+            vanillaRemainingTime.removeAllPlayers();
+            return;
+        }
+        BossEvent.BossBarColor color = BossEvent.BossBarColor.WHITE;
+        if (remainingTimeTicks < 5 * SharedConstants.TICKS_PER_MINUTE) {
+            color = BossEvent.BossBarColor.RED;
+        } else if (remainingTimeTicks < 30 * SharedConstants.TICKS_PER_MINUTE) {
+            color = BossEvent.BossBarColor.PURPLE;
+        }
+        vanillaRemainingTime.setName(Bingo.translatable("bingo.remaining_time_with_value", formatedRemainingTime));
+        vanillaRemainingTime.setColor(color);
     }
 
     public BingoBoard.Teams[] obfuscateTeam(BingoBoard.Teams playerTeam, Player player) {
@@ -243,6 +289,9 @@ public class BingoGame {
 
         ((MinecraftServerExt) playerList.getServer()).bingo$setGame(null);
         new ResyncStatesPayload(board.getStates()).sendTo(playerList.getPlayers());
+        if (scheduledEndTime > 0) {
+            setScheduledEndTime(playerList.getServer(), 0);
+        }
         Bingo.updateCommandTree(playerList);
     }
 
@@ -270,6 +319,14 @@ public class BingoGame {
                         }
                     }
                 }
+            }
+        }
+
+        if (scheduledEndTime > 0 && server.getTickCount() % SharedConstants.TICKS_PER_SECOND == 0) {
+            if (server.overworld().getGameTime() > scheduledEndTime) {
+                endGame(server.getPlayerList());
+            } else {
+                updateVanillaRemainingTime(server);
             }
         }
     }
@@ -774,6 +831,7 @@ public class BingoGame {
         BingoGameMode gameMode,
         boolean requireClient,
         boolean continueAfterWin,
+        long scheduledEndTime,
         int autoForfeitTicks,
         List<String> teamNames,
         Map<UUID, Int2ObjectMap<AdvancementProgress>> advancementProgress,
@@ -803,6 +861,7 @@ public class BingoGame {
                 BingoGameMode.PERSISTENCE_CODEC.fieldOf("game_mode").forGetter(PersistenceData::gameMode),
                 Codec.BOOL.fieldOf("require_client").forGetter(PersistenceData::requireClient),
                 Codec.BOOL.optionalFieldOf("continue_after_win", false).forGetter(PersistenceData::continueAfterWin),
+                ExtraCodecs.NON_NEGATIVE_LONG.optionalFieldOf("scheduled_end_time", 0L).forGetter(PersistenceData::scheduledEndTime),
                 ExtraCodecs.NON_NEGATIVE_INT.optionalFieldOf("auto_forfeit_ticks", DEFAULT_AUTO_FORFEIT_TICKS).forGetter(PersistenceData::autoForfeitTicks),
                 Codec.STRING.listOf().fieldOf("team_names").forGetter(PersistenceData::teamNames),
                 ADVANCEMENT_PROGRESS_CODEC.fieldOf("advancement_progress").forGetter(PersistenceData::advancementProgress),
@@ -825,7 +884,7 @@ public class BingoGame {
                     throw new IllegalStateException("Team '" + teamNames.get(i) + "' no longer exists");
                 }
             }
-            final BingoGame game = new BingoGame(board, gameMode, requireClient, continueAfterWin, autoForfeitTicks, teams);
+            final BingoGame game = new BingoGame(board, gameMode, requireClient, continueAfterWin, scheduledEndTime, autoForfeitTicks, teams);
 
             for (final var entry : advancementProgress.entrySet()) {
                 final Map<ActiveGoal, AdvancementProgress> subTarget = HashMap.newHashMap(entry.getValue().size());
@@ -895,7 +954,8 @@ public class BingoGame {
             }
 
             return new PersistenceData(
-                game.board, game.gameMode, game.requireClient, game.continueAfterWin, game.autoForfeitTicks,
+                game.board, game.gameMode, game.requireClient, game.continueAfterWin,
+                game.scheduledEndTime, game.autoForfeitTicks,
                 Arrays.stream(game.teams).map(PlayerTeam::getName).toList(),
                 createMap(game, game.advancementProgress),
                 createMap(game, game.goalProgress),

--- a/src/main/java/io/github/gaming32/bingo/network/ClientPayloadHandler.java
+++ b/src/main/java/io/github/gaming32/bingo/network/ClientPayloadHandler.java
@@ -4,6 +4,7 @@ import io.github.gaming32.bingo.network.messages.both.ManualHighlightPayload;
 import io.github.gaming32.bingo.network.messages.s2c.InitBoardPayload;
 import io.github.gaming32.bingo.network.messages.s2c.ResyncStatesPayload;
 import io.github.gaming32.bingo.network.messages.s2c.SyncTeamPayload;
+import io.github.gaming32.bingo.network.messages.s2c.UpdateEndTimePayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateProgressPayload;
 import io.github.gaming32.bingo.network.messages.s2c.UpdateStatePayload;
 import io.github.gaming32.bingo.platform.BingoPlatform;
@@ -21,6 +22,8 @@ public interface ClientPayloadHandler {
     void handleUpdateProgress(UpdateProgressPayload payload);
 
     void handleUpdateState(UpdateStatePayload payload);
+
+    void handleUpdateEndTime(UpdateEndTimePayload payload);
 
     void handleManualHighlight(ManualHighlightPayload payload);
 

--- a/src/main/java/io/github/gaming32/bingo/network/messages/s2c/InitBoardPayload.java
+++ b/src/main/java/io/github/gaming32/bingo/network/messages/s2c/InitBoardPayload.java
@@ -25,7 +25,8 @@ public record InitBoardPayload(
     BingoBoard.Teams nerfedTeams,
     BingoGameMode.RenderMode renderMode,
     int[] manualHighlights,
-    int manualHighlightModCount
+    int manualHighlightModCount,
+    long scheduledEndTime
 ) implements AbstractCustomPayload {
     public static final Type<InitBoardPayload> TYPE = AbstractCustomPayload.type("init_board");
     public static final StreamCodec<RegistryFriendlyByteBuf, InitBoardPayload> CODEC = StreamCodec.composite(
@@ -38,10 +39,11 @@ public record InitBoardPayload(
         BingoGameMode.RenderMode.STREAM_CODEC, InitBoardPayload::renderMode,
         BingoStreamCodecs.INT_ARRAY, InitBoardPayload::manualHighlights,
         ByteBufCodecs.VAR_INT, InitBoardPayload::manualHighlightModCount,
+        ByteBufCodecs.LONG, InitBoardPayload::scheduledEndTime,
         InitBoardPayload::new
     );
 
-    public static InitBoardPayload create(BingoGame game, BingoBoard.Teams team, BingoBoard.Teams[] states) {
+    public static InitBoardPayload create(BingoGame game, BingoBoard.Teams team, BingoBoard.Teams[] states, long scheduledEndTime) {
         final BingoBoard board = game.getBoard();
 
         return new InitBoardPayload(
@@ -55,7 +57,8 @@ public record InitBoardPayload(
             game.getNerfedTeams(),
             game.getGameMode().getRenderMode(),
             team.one() ? Arrays.stream(board.getTeamManualHighlights(team)).mapToInt(i -> i == null ? 0 : i + 1).toArray() : new int[board.getShape().getGoalCount(board.getSize())],
-            team.one() ? board.getManualHighlightModCount(team) : 0
+            team.one() ? board.getManualHighlightModCount(team) : 0,
+            scheduledEndTime
         );
     }
 

--- a/src/main/java/io/github/gaming32/bingo/network/messages/s2c/UpdateEndTimePayload.java
+++ b/src/main/java/io/github/gaming32/bingo/network/messages/s2c/UpdateEndTimePayload.java
@@ -1,0 +1,23 @@
+package io.github.gaming32.bingo.network.messages.s2c;
+
+import io.github.gaming32.bingo.network.AbstractCustomPayload;
+import io.github.gaming32.bingo.platform.BingoNetworking;
+import io.github.gaming32.bingo.network.ClientPayloadHandler;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+
+public record UpdateEndTimePayload(long endTime) implements AbstractCustomPayload {
+    public static final Type<UpdateEndTimePayload> TYPE = AbstractCustomPayload.type("update_end_time");
+    public static final StreamCodec<ByteBuf, UpdateEndTimePayload> CODEC = ByteBufCodecs.VAR_LONG.map(UpdateEndTimePayload::new, UpdateEndTimePayload::endTime);
+
+    @Override
+    public Type<UpdateEndTimePayload> type() {
+        return TYPE;
+    }
+
+    @Override
+    public void handle(BingoNetworking.Context context) {
+        ClientPayloadHandler.get().handleUpdateEndTime(this);
+    }
+}

--- a/src/main/java/io/github/gaming32/bingo/platform/BingoNetworking.java
+++ b/src/main/java/io/github/gaming32/bingo/platform/BingoNetworking.java
@@ -28,7 +28,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public final class BingoNetworking {
-    public static final int PROTOCOL_VERSION = 12;
+    public static final int PROTOCOL_VERSION = 13;
 
     public static void onRegister(Consumer<Registrar> handler) {
         handler.accept(new Registrar());

--- a/src/main/java/io/github/gaming32/bingo/util/BingoUtil.java
+++ b/src/main/java/io/github/gaming32/bingo/util/BingoUtil.java
@@ -13,6 +13,7 @@ import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.JsonOps;
 import io.github.gaming32.bingo.Bingo;
 import it.unimi.dsi.fastutil.Hash;
+import net.minecraft.SharedConstants;
 import net.minecraft.commands.arguments.ResourceOrTagKeyArgument;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
@@ -220,6 +221,21 @@ public class BingoUtil {
             }
         }
         return Either.right(team.getDisplayName());
+    }
+
+    public static String formatRemainingTime(long remainingTimeTicks) {
+        if (remainingTimeTicks < 0)
+            remainingTimeTicks = 0;
+        int hours = (int) (remainingTimeTicks / SharedConstants.TICKS_PER_MINUTE / 60);
+        int minutes = (int) (remainingTimeTicks / SharedConstants.TICKS_PER_MINUTE % 60);
+        int seconds = (int) (remainingTimeTicks / SharedConstants.TICKS_PER_SECOND % 60);
+        StringBuilder sb = new StringBuilder();
+        if (hours > 0) {
+            sb.append(hours);
+            sb.append(":");
+        }
+        sb.append(String.format("%02d:%02d", minutes, seconds));
+        return sb.toString();
     }
 
     public static <T, R> Either<R, R> mapEither(Either<? extends T, ? extends T> either, Function<? super T, ? extends R> mapper) {

--- a/src/main/resources/assets/bingo/lang/en_us.json
+++ b/src/main/resources/assets/bingo/lang/en_us.json
@@ -320,6 +320,8 @@
   "bingo.key.manual_highlight": "Manual Highlight",
   "bingo.sixteen_bang": "%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, and %s!",
   "bingo.unclaimed": "Unclaimed",
+  "bingo.remaining_time": "Remaining time",
+  "bingo.remaining_time_with_value": "Remaining time: %s",
   "bingo.three": "%s, %s, and %s",
   "bingo.four": "%s, %s, %s, and %s",
   "bingo.spawner": "%s %s",


### PR DESCRIPTION
This adds another start parameter `--time <total time in minutes>` and a new command `bingo time set <remaining time in minutes>` to set a countdown that will end the game when it reaches 0.

For modded clients, the countdown is shown below the board, for vanilla clients it's shown as a boss bar.

![image](https://github.com/user-attachments/assets/33c64871-a065-4b55-8ecb-99d84c63280b)
![image](https://github.com/user-attachments/assets/43c19b74-f3f2-410d-ad41-d87f97a7cc02)

I don't know if the command syntax is ideal, i thought about having a more elaborate command like `--time <value> <time unit>`.

I had to convert the `ClientGame` record into a class which might be a bit messy.

closes #27 